### PR TITLE
Add ML pipeline skeleton with simulation and tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+.venv/
+logs/
+reports/
+models/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "run_pipeline.py", "simulate"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # LLM-ATC
-LLM based CD and Resolution in ATC.
+
+A toy pipeline for ML-based conflict detection and hallucination monitoring in air-traffic control.
+
+## Setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage
+
+Prepare some `data/adsb.csv` and `data/scat.csv` files.
+
+Run the pipeline:
+
+```bash
+python run_pipeline.py prepare-data
+python run_pipeline.py train
+python run_pipeline.py simulate
+```
+
+Logs go to `logs/`, reports to `reports/`.
+
+## Tests
+
+```bash
+pytest
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+services:
+  atc:
+    build: .
+    volumes:
+      - .:/app
+    command: bash -c "pip install -r requirements.txt && pytest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 88
+skip-string-normalization = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+pandas
+scikit-learn
+xgboost
+joblib
+torch
+pytest
+flake8
+black

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,0 +1,73 @@
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from src.llm_atc.data import (
+    load_adsb_data,
+    load_scat_data,
+    label_conflicts,
+    save_json_trace,
+)
+from src.llm_atc.hallucination import Envelope
+from src.llm_atc.model import BaselineModel
+from src.llm_atc.simulate import DummyBlueSky, simulate
+
+
+BASE_DIR = Path(__file__).parent
+DATA_DIR = BASE_DIR / "data"
+MODEL_DIR = BASE_DIR / "models"
+LOG_DIR = BASE_DIR / "logs"
+REPORT_DIR = BASE_DIR / "reports"
+
+
+def prepare_data() -> None:
+    adsb_path = DATA_DIR / "adsb.csv"
+    scat_path = DATA_DIR / "scat.csv"
+    adsb = load_adsb_data(adsb_path)
+    scat = load_scat_data(scat_path)
+    df = pd.concat([adsb, scat], ignore_index=True, sort=False)
+    df = label_conflicts(df)
+    df.to_csv(DATA_DIR / "prepared.csv", index=False)
+
+
+def train() -> None:
+    df = pd.read_csv(DATA_DIR / "prepared.csv")
+    model = BaselineModel()
+    acc = model.train(df)
+    model.save(MODEL_DIR / "baseline.joblib")
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    with open(REPORT_DIR / "train_metrics.txt", "w") as f:
+        f.write(f"accuracy: {acc}\n")
+
+
+def simulate_mode() -> None:
+    df = pd.read_csv(DATA_DIR / "prepared.csv")
+    model = BaselineModel()
+    model.load(MODEL_DIR / "baseline.joblib")
+    envelope = Envelope.from_training(df.drop(columns=["conflict"]))
+    env = DummyBlueSky(df.drop(columns=["conflict"]))
+    simulate(model, env, envelope, LOG_DIR / "trace.json")
+
+
+def evaluate() -> None:
+    print("Evaluation placeholder")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "mode", choices=["prepare-data", "train", "simulate", "evaluate"]
+    )
+    args = parser.parse_args()
+
+    LOG_DIR.mkdir(exist_ok=True)
+
+    if args.mode == "prepare-data":
+        prepare_data()
+    elif args.mode == "train":
+        train()
+    elif args.mode == "simulate":
+        simulate_mode()
+    elif args.mode == "evaluate":
+        evaluate()

--- a/src/llm_atc/data.py
+++ b/src/llm_atc/data.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+from typing import Tuple
+
+import pandas as pd
+
+
+def load_adsb_data(path: Path) -> pd.DataFrame:
+    """Load ADS-B data from a CSV file."""
+    if not path.exists():
+        raise FileNotFoundError(path)
+    df = pd.read_csv(path)
+    return df
+
+
+def load_scat_data(path: Path) -> pd.DataFrame:
+    """Load SCAT dataset CSV."""
+    if not path.exists():
+        raise FileNotFoundError(path)
+    df = pd.read_csv(path)
+    return df
+
+
+def label_conflicts(df: pd.DataFrame) -> pd.DataFrame:
+    """Simple conflict labeling based on separation minima."""
+    df = df.copy()
+    df["conflict"] = (df.get("horizontal_sep", 10000) < 5) & (
+        df.get("vertical_sep", 2000) < 1000
+    )
+    return df
+
+
+def save_json_trace(data: dict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)

--- a/src/llm_atc/hallucination.py
+++ b/src/llm_atc/hallucination.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class Envelope:
+    lower: pd.Series
+    upper: pd.Series
+
+    @classmethod
+    def from_training(cls, df: pd.DataFrame) -> "Envelope":
+        mean = df.mean()
+        std = df.std()
+        lower = mean - 3 * std
+        upper = mean + 3 * std
+        return cls(lower=lower, upper=upper)
+
+    def check(self, sample: pd.Series) -> Dict[str, float]:
+        out_of_bounds = {}
+        for col in sample.index:
+            val = sample[col]
+            if val < self.lower[col] or val > self.upper[col]:
+                dist = min(self.lower[col] - val, val - self.upper[col])
+                out_of_bounds[col] = abs(dist)
+        return out_of_bounds
+
+
+def severity_score(out_of_bounds: Dict[str, float]) -> float:
+    if not out_of_bounds:
+        return 0.0
+    return float(np.mean(list(out_of_bounds.values())))

--- a/src/llm_atc/model.py
+++ b/src/llm_atc/model.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+from typing import Tuple
+
+import joblib
+import pandas as pd
+import torch
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score
+from xgboost import XGBClassifier
+
+
+class BaselineModel:
+    def __init__(self) -> None:
+        self.model = XGBClassifier(
+            n_estimators=50,
+            max_depth=5,
+            objective="binary:logistic",
+            eval_metric="logloss",
+        )
+
+    def train(self, df: pd.DataFrame, target: str = "conflict") -> float:
+        X = df.drop(columns=[target])
+        y = df[target]
+        X_train, X_val, y_train, y_val = train_test_split(
+            X, y, test_size=0.2, random_state=42
+        )
+        self.model.fit(X_train, y_train)
+        preds = self.model.predict(X_val)
+        return accuracy_score(y_val, preds)
+
+    def predict(self, df: pd.DataFrame) -> pd.Series:
+        return pd.Series(self.model.predict_proba(df)[:, 1], index=df.index)
+
+    def save(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        joblib.dump(self.model, path)
+
+    def load(self, path: Path) -> None:
+        self.model = joblib.load(path)
+
+
+class TransformerModel(torch.nn.Module):
+    def __init__(self, input_dim: int, hidden_dim: int = 64, num_layers: int = 2):
+        super().__init__()
+        encoder_layer = torch.nn.TransformerEncoderLayer(
+            d_model=input_dim, nhead=4, dim_feedforward=hidden_dim
+        )
+        self.transformer = torch.nn.TransformerEncoder(encoder_layer, num_layers)
+        self.fc = torch.nn.Linear(input_dim, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.transformer(x)
+        out = self.fc(x.mean(dim=0))
+        return torch.sigmoid(out)
+
+
+class TimeSeriesModel:
+    def __init__(self, input_dim: int):
+        self.net = TransformerModel(input_dim)
+        self.criterion = torch.nn.BCELoss()
+        self.optimizer = torch.optim.Adam(self.net.parameters(), lr=1e-3)
+
+    def train(
+        self, tensor: torch.Tensor, labels: torch.Tensor, epochs: int = 5
+    ) -> float:
+        self.net.train()
+        for _ in range(epochs):
+            self.optimizer.zero_grad()
+            out = self.net(tensor)
+            loss = self.criterion(out.squeeze(), labels.float())
+            loss.backward()
+            self.optimizer.step()
+        return loss.item()
+
+    def predict(self, tensor: torch.Tensor) -> torch.Tensor:
+        self.net.eval()
+        with torch.no_grad():
+            return self.net(tensor).squeeze()
+
+    def save(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(self.net.state_dict(), path)
+
+    def load(self, path: Path, input_dim: int) -> None:
+        self.net = TransformerModel(input_dim)
+        self.net.load_state_dict(torch.load(path))

--- a/src/llm_atc/simulate.py
+++ b/src/llm_atc/simulate.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+from .hallucination import Envelope, severity_score
+from .model import BaselineModel
+
+
+class DummyBlueSky:
+    """Placeholder for BlueSky simulation."""
+
+    def __init__(self, df: pd.DataFrame):
+        self.df = df
+
+    def run(self) -> Iterable[pd.Series]:
+        for _, row in self.df.iterrows():
+            yield row
+
+
+def simulate(
+    model: BaselineModel,
+    env: DummyBlueSky,
+    envelope: Envelope,
+    trace_path: Path,
+) -> None:
+    logs = []
+    for step in env.run():
+        prob = model.predict(step.to_frame().T).iloc[0]
+        bounds = envelope.check(step)
+        sev = severity_score(bounds)
+        logs.append(
+            {
+                "step": step.to_dict(),
+                "prob": float(prob),
+                "hallucination": bounds,
+                "severity": sev,
+            }
+        )
+    trace_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(trace_path, "w") as f:
+        import json
+
+        json.dump(logs, f, indent=2)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+import pandas as pd
+
+from src.llm_atc.data import load_adsb_data
+
+
+def test_load_adsb(tmp_path):
+    f = tmp_path / "adsb.csv"
+    pd.DataFrame({"a": [1], "b": [2]}).to_csv(f, index=False)
+    df = load_adsb_data(f)
+    assert not df.empty

--- a/tests/test_hallucination.py
+++ b/tests/test_hallucination.py
@@ -1,0 +1,10 @@
+import pandas as pd
+from src.llm_atc.hallucination import Envelope
+
+
+def test_envelope():
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    env = Envelope.from_training(df)
+    sample = pd.Series({"a": 100})
+    res = env.check(sample)
+    assert "a" in res

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,11 @@
+import pandas as pd
+from src.llm_atc.model import BaselineModel
+
+
+def test_baseline_train(tmp_path):
+    df = pd.DataFrame({"f1": [0, 1], "conflict": [0, 1]})
+    model = BaselineModel()
+    acc = model.train(df)
+    path = tmp_path / "model.joblib"
+    model.save(path)
+    assert path.exists()


### PR DESCRIPTION
## Summary
- implement minimal conflict detection pipeline
- add baseline and transformer models
- create hallucination detection utilities
- add dummy BlueSky simulator and `run_pipeline.py`
- provide unit tests, Docker setup and lint configs

## Testing
- `flake8 src tests run_pipeline.py` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68494c090ae883338775be2c0c6d5b2d